### PR TITLE
Update find selector and make auto-folding an option

### DIFF
--- a/foldpythondocstrings.py
+++ b/foldpythondocstrings.py
@@ -9,7 +9,7 @@ def fold_comments(view):
             region = sublime.Region(lines[0].begin(), lines[-1].end())
             text = view.substr(region).strip()
             if text.startswith("'''") or text.startswith('"""'):
-                fold_region = sublime.Region(lines[0].end() - 1, lines[-1].end() - 3)
+                fold_region = sublime.Region(lines[0].end(), lines[-1].end() - 3)
                 view.fold(fold_region)
 
 


### PR DESCRIPTION
The longer selector does not match normal strings and should reduce the overhead. Also make auto-folding optional by considering a "fold_python_docstrings_onload" setting which can be set in "User/Preferences.sublime-settings".
