### PR TITLE
Add optional number of lines to fold setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ On OSX these are bound to ⌘⇧- and ⌘⇧=, respectively.
 
 ### Configuration
 
-To disable folding on initial load add the following to `User/Preferences.sublime-settings`:
+The following settings can be changed in `User/Preferences.sublime-settings`:
 
-`"fold_python_docstrings_onload": false`
+**fold_python_docstrings_onload**
+
+Set to `false` to disable folding on initial load
+
+**fold_python_docstrings_number_of_lines**
+
+Set to this to an integer to fold the docstring to this number of lines
+

--- a/foldpythondocstrings.py
+++ b/foldpythondocstrings.py
@@ -3,13 +3,14 @@ import sublime_plugin
 
 
 def fold_comments(view):
+    number_lines_to_fold = view.settings().get("fold_python_docstrings_number_of_lines", 1)
     for region in view.find_by_selector('string.quoted.double.block, string.quoted.single.block'):
         lines = view.lines(region)
         if len(lines) > 1:
             region = sublime.Region(lines[0].begin(), lines[-1].end())
             text = view.substr(region).strip()
             if text.startswith("'''") or text.startswith('"""'):
-                fold_region = sublime.Region(lines[0].end(), lines[-1].end() - 3)
+                fold_region = sublime.Region(lines[number_lines_to_fold-1].end(), lines[-1].end() - 3)
                 view.fold(fold_region)
 
 


### PR DESCRIPTION
Add "fold_python_docstrings_number_of_lines" setting which can be set in
"User/Preferences.sublime-settings".
