### PR TITLE
Readablity and nicer handling of a special-case

### DIFF
--- a/foldpythondocstrings.py
+++ b/foldpythondocstrings.py
@@ -8,6 +8,9 @@ def fold_comments(view):
     number_lines_to_fold = view.settings().get(
         "fold_python_docstrings_number_of_lines", 1
     )
+    show_ending_quotes_on_separate_line = view.settings().get(
+        "fold_python_docstrings_show_ending_quotes_on_separate_line", False
+    )
 
     for region in view.find_by_selector(selectors):
         lines = view.lines(region)
@@ -22,6 +25,15 @@ def fold_comments(view):
         # Moved out for readability
         a = lines[number_lines_to_fold - 1].end()
         b = lines[-1].end() - 3
+
+        # **Special Case**
+        # When the doc-string ending quotes are on their own separate line,
+        # show it on a separate line.
+        if show_ending_quotes_on_separate_line:
+            first_non_tab_or_space_char_at_end = text[:-3].rstrip(" \t")[-1]
+            if first_non_tab_or_space_char_at_end == "\n":
+                # Move to before the new-line.
+                b -= (len(text) - text.rfind("\n") - 3)
 
         fold_region = sublime.Region(a, b)
         view.fold(fold_region)

--- a/foldpythondocstrings.py
+++ b/foldpythondocstrings.py
@@ -1,10 +1,11 @@
 import sublime
 import sublime_plugin
 
+SELECTOR = 'string.quoted.double.block, string.quoted.single.block'
+
 
 def fold_comments(view):
-    # Selector moved out for readability
-    selectors = 'string.quoted.double.block, string.quoted.single.block'
+    # Settings
     number_lines_to_fold = view.settings().get(
         "fold_python_docstrings_number_of_lines", 1
     )
@@ -12,7 +13,7 @@ def fold_comments(view):
         "fold_python_docstrings_show_ending_quotes_on_separate_line", False
     )
 
-    for region in view.find_by_selector(selectors):
+    for region in view.find_by_selector(SELECTOR):
         lines = view.lines(region)
         if len(lines) <= 1:
             continue
@@ -58,4 +59,4 @@ class FoldPythonDocstringsCommand(sublime_plugin.TextCommand):
 
 class UnfoldPythonDocstringsCommand(sublime_plugin.TextCommand):
     def run(self, edit):
-        self.view.unfold(self.view.find_by_selector('string'))
+        self.view.unfold(self.view.find_by_selector(SELECTOR))

--- a/foldpythondocstrings.py
+++ b/foldpythondocstrings.py
@@ -3,15 +3,28 @@ import sublime_plugin
 
 
 def fold_comments(view):
-    number_lines_to_fold = view.settings().get("fold_python_docstrings_number_of_lines", 1)
-    for region in view.find_by_selector('string.quoted.double.block, string.quoted.single.block'):
+    # Selector moved out for readability
+    selectors = 'string.quoted.double.block, string.quoted.single.block'
+    number_lines_to_fold = view.settings().get(
+        "fold_python_docstrings_number_of_lines", 1
+    )
+
+    for region in view.find_by_selector(selectors):
         lines = view.lines(region)
-        if len(lines) > 1:
-            region = sublime.Region(lines[0].begin(), lines[-1].end())
-            text = view.substr(region).strip()
-            if text.startswith("'''") or text.startswith('"""'):
-                fold_region = sublime.Region(lines[number_lines_to_fold-1].end(), lines[-1].end() - 3)
-                view.fold(fold_region)
+        if len(lines) <= 1:
+            continue
+
+        region = sublime.Region(lines[0].begin(), lines[-1].end())
+        text = view.substr(region).strip()
+        if not text.startswith(("'''", '"""')):
+            continue
+
+        # Moved out for readability
+        a = lines[number_lines_to_fold - 1].end()
+        b = lines[-1].end() - 3
+
+        fold_region = sublime.Region(a, b)
+        view.fold(fold_region)
 
 
 class FoldFilePythonDocstrings(sublime_plugin.EventListener):

--- a/foldpythondocstrings.py
+++ b/foldpythondocstrings.py
@@ -22,9 +22,15 @@ def fold_comments(view):
         if not text.startswith(("'''", '"""')):
             continue
 
-        # Moved out for readability
+        # **Edge Case**
+        # If we have a comma, parenthesis or spaces after the quotes
+        adjustment = 3
+        while text[-1] != text[1]:
+            adjustment += 1
+            text = text[:-1]
+
         a = lines[number_lines_to_fold - 1].end()
-        b = lines[-1].end() - 3
+        b = lines[-1].end() - adjustment
 
         # **Special Case**
         # When the doc-string ending quotes are on their own separate line,
@@ -33,7 +39,7 @@ def fold_comments(view):
             first_non_tab_or_space_char_at_end = text[:-3].rstrip(" \t")[-1]
             if first_non_tab_or_space_char_at_end == "\n":
                 # Move to before the new-line.
-                b -= (len(text) - text.rfind("\n") - 3)
+                b -= len(text) - text.rfind("\n") - 3
 
         fold_region = sublime.Region(a, b)
         view.fold(fold_region)


### PR DESCRIPTION
This PR improves the readability of code in the `fold_comments` function and adds special handling for the case where the doc-string quotes at the end of line are on their separate line.

Here's an example of why I added the special case:

![fold-python-docstrings-pr](https://cloud.githubusercontent.com/assets/3275593/9292169/2b2a7a44-4407-11e5-8a8d-6659e9946dae.png)
