### PR TITLE
Support MagicPython Syntax

### DIFF
--- a/foldpythondocstrings.py
+++ b/foldpythondocstrings.py
@@ -1,10 +1,22 @@
 import sublime
 import sublime_plugin
 
+docstring_selectors = [
+    'string.quoted.double.block',
+    'string.quoted.single.block',
+    'string.quoted.docstring',
+]
+
+docstring_startswith = [
+    "'''",
+    '"""',
+    'r"""',
+]
+
 
 def fold_comments(view):
     number_lines_to_fold = view.settings().get('fold_python_docstrings_number_of_lines', 1)
-    for region in view.find_by_selector('string.quoted.double.block, string.quoted.single.block, string.quoted.docstring'):
+    for region in view.find_by_selector(', '.join(docstring_selectors)):
         lines = view.lines(region)
         if len(lines) <= 1:
             continue
@@ -12,7 +24,7 @@ def fold_comments(view):
         region = sublime.Region(lines[0].begin(), lines[-1].end())
         text = view.substr(region).strip()
 
-        if not (text.startswith("'''") or text.startswith('"""') or text.startswith('r"""')):
+        if not (text.startswith(tuple(docstring_startswith))):
             continue
 
         # Handle docstrings with just quotes on the first line.

--- a/foldpythondocstrings.py
+++ b/foldpythondocstrings.py
@@ -4,7 +4,7 @@ import sublime_plugin
 
 def fold_comments(view):
     number_lines_to_fold = view.settings().get('fold_python_docstrings_number_of_lines', 1)
-    for region in view.find_by_selector('string.quoted.double.block, string.quoted.single.block'):
+    for region in view.find_by_selector('string.quoted.double.block, string.quoted.single.block, string.quoted.docstring'):
         lines = view.lines(region)
         if len(lines) <= 1:
             continue
@@ -12,7 +12,7 @@ def fold_comments(view):
         region = sublime.Region(lines[0].begin(), lines[-1].end())
         text = view.substr(region).strip()
 
-        if not (text.startswith("'''") or text.startswith('"""')):
+        if not (text.startswith("'''") or text.startswith('"""') or text.startswith('r"""')):
             continue
 
         # Handle docstrings with just quotes on the first line.


### PR DESCRIPTION
[MagicPython](https://github.com/MagicStack/MagicPython) is an improved Python Syntax Highlighter for Sublime.

Uses [`string.quoted.docstring.*`](https://github.com/MagicStack/MagicPython/blob/652811554d239c938af52ffb426a16345f4b5aef/grammars/src/MagicPython.syntax.yaml#L141) pattern.