### PR TITLE
Update to include comment.block as a selector

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,0 +1,24 @@
+[
+  {
+    "keys": ["ctrl+shift+minus"],
+    "command": "fold_python_docstrings",
+    "context": [
+      {
+        "key": "selector",
+        "operator": "equal",
+        "operand": "source.python"
+      }
+    ]
+  },
+  {
+    "keys": ["ctrl+shift+equals"],
+    "command": "unfold_python_docstrings",
+    "context": [
+      {
+        "key": "selector",
+        "operator": "equal",
+        "operand": "source.python"
+      }
+    ]
+  }
+]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,0 +1,24 @@
+[
+  {
+    "keys": ["ctrl+shift+minus"],
+    "command": "fold_python_docstrings",
+    "context": [
+      {
+        "key": "selector",
+        "operator": "equal",
+        "operand": "source.python"
+      }
+    ]
+  },
+  {
+    "keys": ["ctrl+shift+equals"],
+    "command": "unfold_python_docstrings",
+    "context": [
+      {
+        "key": "selector",
+        "operator": "equal",
+        "operand": "source.python"
+      }
+    ]
+  }
+]

--- a/foldpythondocstrings.py
+++ b/foldpythondocstrings.py
@@ -58,5 +58,4 @@ class FoldPythonDocstringsCommand(sublime_plugin.TextCommand):
 class UnfoldPythonDocstringsCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
-        self.view.unfold(self.view.find_by_selector('string'))
-        self.view.unfold(self.view.find_by_selector('comment.block'))
+        self.view.unfold(self.view.find_by_selector('string', 'comment.block'))

--- a/foldpythondocstrings.py
+++ b/foldpythondocstrings.py
@@ -58,4 +58,4 @@ class FoldPythonDocstringsCommand(sublime_plugin.TextCommand):
 class UnfoldPythonDocstringsCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
-        self.view.unfold(self.view.find_by_selector('string', 'comment.block'))
+        self.view.unfold(self.view.find_by_selector('string, comment.block'))

--- a/foldpythondocstrings.py
+++ b/foldpythondocstrings.py
@@ -5,6 +5,7 @@ docstring_selectors = [
     'string.quoted.double.block',
     'string.quoted.single.block',
     'string.quoted.docstring',
+    'comment.block',
 ]
 
 docstring_startswith = [
@@ -58,3 +59,4 @@ class UnfoldPythonDocstringsCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
         self.view.unfold(self.view.find_by_selector('string'))
+        self.view.unfold(self.view.find_by_selector('comment.block'))


### PR DESCRIPTION
Sublime's latest syntax highlighting identifies a Python docstring as a "comment.block", not a "string.quoted". I added "comment.block" to the list of docstring_selectors so that folding docstrings now works with Sublime build 3114.
